### PR TITLE
Fix compiling error with OpenCV

### DIFF
--- a/steps_taken.txt
+++ b/steps_taken.txt
@@ -38,7 +38,8 @@ cmake -D CMAKE_BUILD_TYPE=RELEASE \
     -D CMAKE_INSTALL_PREFIX=/usr/local \
     -D INSTALL_PYTHON_EXAMPLES=ON \
     -D OPENCV_EXTRA_MODULES_PATH=~/opencv_contrib-3.1.0/modules \
-    -D BUILD_EXAMPLES=ON ..
+    -D BUILD_EXAMPLES=ON .. \
+    -D ENABLE_PRECOMPILED_HEADERS=OFF
     
 # This step takes a long time...
 make -j4


### PR DESCRIPTION
Fix a compilation error with OpenCV: `fatal error: stdlib.h: No such file or directory`.

I followed that [SO thread](https://stackoverflow.com/questions/40262928/error-compiling-opencv-fatal-error-stdlib-h-no-such-file-or-directory).